### PR TITLE
Add yoshi-kokoro as admin

### DIFF
--- a/users.json
+++ b/users.json
@@ -12,7 +12,8 @@
         "danoscarmike",
         "broady",
         "kokoro-team",
-        "yoshi-automation"
+        "yoshi-automation",
+        "yoshi-kokoro"
       ],
       "repos": [
 


### PR DESCRIPTION
yoshi-kokoro's GitHub access token will be used for client library Kokoro runs.