### PR TITLE
chore: remove GoogleCloudPlatform org

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -12,7 +12,7 @@
     { "language": "go", "repo": "googleapis/gax-go"},
     { "language": "go", "repo": "googleapis/google-api-go-client"},
     { "language": "go", "repo": "googleapis/google-cloud-go-testing"},
-    { "language": "go", "repo": "googlecloudplatform/google-cloud-go"},
+    { "language": "go", "repo": "googleapis/google-cloud-go"},
 
     { "language": "java", "repo": "googleapis/api-common-java"},
     { "language": "java", "repo": "googleapis/cloud-bigtable-client"},

--- a/src/repos.ts
+++ b/src/repos.ts
@@ -40,7 +40,7 @@ export async function syncRepoSettings() {
   // The Go repositories are synchronized with a different git
   // repository, so direct commits need to be made.
   const ignoreRepos =
-      ['GoogleCloudPlatform/google-cloud-go', 'google/google-api-go-client'];
+      ['googleapis/google-cloud-go', 'googleapis/google-api-go-client'];
 
   const ps3 =
       repos

--- a/users.json
+++ b/users.json
@@ -1,6 +1,5 @@
 {
   "orgs": [
-    "GoogleCloudPlatform",
     "googleapis"
   ],
   "membership": [


### PR DESCRIPTION
As of right now, it looks like all of our repos are actually in the `googleapis` GitHub org!  This makes automation so much easier.