### PR TITLE
feat: ignore external issues from SLO

### DIFF
--- a/labels.json
+++ b/labels.json
@@ -134,6 +134,11 @@
       "name": "good first issue",
       "description": "This issue is a good place to started contributing to this repository.",
       "color": "520b77"
+    },
+    {
+      "name": "external",
+      "description": "This issue is blocked on a bug with the actual product.",
+      "color": "800080"
     }
   ]
 }

--- a/src/issue.ts
+++ b/src/issue.ts
@@ -357,6 +357,11 @@ function isOutOfSLO(i: ApiIssue) {
     return false;
   }
 
+  // Ignore any issues which are blocked by external APIs
+  if (isExternal(i)) {
+    return false;
+  }
+
   // All P0 issues must receive a reply within 1 day, an update at least daily,
   // and be resolved within 5 days.
   if (pri === 0) {
@@ -424,6 +429,10 @@ function daysOld(date: string) {
  */
 function hoursOld(date: string) {
   return (Date.now() - new Date(date).getTime()) / 1000 / 60 / 60;
+}
+
+function isExternal(i: ApiIssue) {
+  return hasLabel(i, 'external');
 }
 
 /**


### PR DESCRIPTION
We discussed this today in the team meeting.  Issues that are blocked on an external API can now be tagged with the `external` label.  This will ensure they are not included in SLO calculations.