### PR TITLE
feat: stop tracking googleapis/oauth2client

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -222,7 +222,6 @@
     { "language": "python", "repo": "googleapis/python-ndb", "apiHint": "ndb"},
     { "language": "python", "repo": "googleapis/google-cloud-python-happybase", "apiHint": "bigtable"},
     { "language": "python", "repo": "googleapis/google-resumable-media-python", "apiHint": "storage"},
-    { "language": "python", "repo": "googleapis/oauth2client"},
     { "language": "python", "repo": "googleapis/releasetool"},
     { "language": "python", "repo": "googleapis/synthtool"},
     { "language": "python", "repo": "googleapis/docuploader"},

--- a/users.json
+++ b/users.json
@@ -425,7 +425,6 @@
         "googleapis/google-cloud-python",
         "googleapis/google-cloud-python-happybase",
         "googleapis/google-resumable-media-python",
-        "googleapis/oauth2client",
         "googleapis/google-auth-library-python-oauthlib"
       ]
     },


### PR DESCRIPTION
This is the deprecated Python 2 oauth client, which has been replaced.  Just to make sure folks don't get confused, we went ahead and archived the repository.