### PR TITLE
fix: gce-images should now be nodejs-gce-images

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -102,7 +102,7 @@
     { "language": "nodejs", "repo": "googleapis/cloud-trace-nodejs", "apiHint": "cloudtrace"},
     { "language": "nodejs", "repo": "googleapis/gax-nodejs"},
     { "language": "nodejs", "repo": "googleapis/gaxios"},
-    { "language": "nodejs", "repo": "googleapis/gce-images", "apiHint": "compute"},
+    { "language": "nodejs", "repo": "googleapis/nodejs-gce-images", "apiHint": "compute"},
     { "language": "nodejs", "repo": "googleapis/gcp-metadata"},
     { "language": "nodejs", "repo": "googleapis/gcs-resumable-upload", "apiHint": "storage"},
     { "language": "nodejs", "repo": "googleapis/github-repo-automation"},

--- a/users.json
+++ b/users.json
@@ -103,7 +103,7 @@
         "googleapis/cloud-trace-nodejs",
         "googleapis/gax-nodejs",
         "googleapis/gaxios",
-        "googleapis/gce-images",
+        "googleapis/nodejs-gce-images",
         "googleapis/gcp-metadata",
         "googleapis/gcs-resumable-upload",
         "googleapis/google-api-nodejs-client",


### PR DESCRIPTION
fixes the link in sloth for gce-images, we will likely need to update kokoro too.