### PR TITLE
fix: add github-repo-automation to nodejs group

### DIFF
--- a/users.json
+++ b/users.json
@@ -111,6 +111,7 @@
         "googleapis/google-cloud-kvstore",
         "googleapis/google-cloud-node",
         "googleapis/google-p12-pem",
+        "googleapis/github-repo-automation",
         "googleapis/node-gtoken",
         "googleapis/nodejs-asset",
         "googleapis/nodejs-automl",


### PR DESCRIPTION
folks in the Node.js group don't have access to github-repo-automation for maintenance.
