### PR TITLE
fix: drop nodejs-common-grpc module

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -127,7 +127,6 @@
     { "language": "nodejs", "repo": "googleapis/nodejs-cloud-container", "apiHint": "container"},
     { "language": "nodejs", "repo": "googleapis/nodejs-cloudbuild", "apiHint": "cloudbuild"},
     { "language": "nodejs", "repo": "googleapis/nodejs-common"},
-    { "language": "nodejs", "repo": "googleapis/nodejs-common-grpc"},
     { "language": "nodejs", "repo": "googleapis/nodejs-compute", "apiHint": "compute"},
     { "language": "nodejs", "repo": "googleapis/nodejs-containeranalysis", "apiHint": "containeranalysis"},
     { "language": "nodejs", "repo": "googleapis/nodejs-datacatalog", "apiHint": "datacatalog"},

--- a/users.json
+++ b/users.json
@@ -121,7 +121,6 @@
         "googleapis/nodejs-billing-budgets",
         "googleapis/nodejs-cloud-container",
         "googleapis/nodejs-common",
-        "googleapis/nodejs-common-grpc",
         "googleapis/nodejs-compute",
         "googleapis/nodejs-containeranalysis",
         "googleapis/nodejs-datacatalog",


### PR DESCRIPTION
This module is no longer used, and we're archiving the repo. 