### PR TITLE
feat: add nightly snapshot job

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,6 +11,7 @@ jobs:
           node-version: 12
       - run: npm install
       - run: npm run compile
-      - run: node build/src/exportToBigQuery.js --datasetId yoshi_github_slo --tableId issues_raw --projectId yoshi-status
-
-
+      - run: echo $KEYFILE_CONTENTS | base64 --decode > keyfile.json
+        env:
+          KEYFILE_CONTENTS: ${{ secrets.KEYFILE_CONTENTS }}
+      - run: GOOGLE_APPLICATION_CREDENTIALS=./keyfile.json node ./build/src/exportToBigQuery.js --datasetId yoshi_github_slo --tableId issues_raw --projectId yoshi-status

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,16 @@
+on:
+  schedule:
+    - cron:  '0 2 * * *'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+      - run: npm run compile
+      - run: node build/src/exportToBigQuery.js --datasetId yoshi_github_slo --tableId issues_raw --projectId yoshi-status
+
+

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,8 @@ jobs:
           node-version: 12
       - run: npm install
       - run: npm run compile
-      - run: echo $KEYFILE_CONTENTS | base64 --decode > keyfile.json
+      - run: echo $KEYFILE_CONTENTS | base64 --decode > /tmp/keyfile.json
         env:
           KEYFILE_CONTENTS: ${{ secrets.KEYFILE_CONTENTS }}
-      - run: GOOGLE_APPLICATION_CREDENTIALS=./keyfile.json node ./build/src/exportToBigQuery.js --datasetId yoshi_github_slo --tableId issues_raw --projectId yoshi-status
+      - run: cat /tmp/keyfile.json
+      - run: GOOGLE_APPLICATION_CREDENTIALS=/tmp/keyfile.json node ./build/src/exportToBigQuery.js --datasetId yoshi_github_slo --tableId issues_raw --projectId yoshi-status

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "author": "Justin Beckwith",
   "license": "Apache-2.0",
   "dependencies": {
+    "@google-cloud/bigquery": "^4.7.0",
     "@octokit/rest": "16.43.1",
     "cli-table": "^0.3.1",
     "csv-string": "^3.1.5",

--- a/src/exportToBigQuery.ts
+++ b/src/exportToBigQuery.ts
@@ -1,0 +1,85 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {BigQuery} from '@google-cloud/bigquery';
+import meow = require('meow');
+import { getIssues } from './issue';
+import { Issue } from './types';
+
+const cli = meow(
+  `
+	Usage
+	  $ build/src/exportToBigQuery
+
+  Options
+    --datasetId   DataSetId to use in BigQuery
+    --tableId     TableId to use in BigQuery
+    --projectId   ProjectId to use in BigQuery
+
+	Examples
+    $ build/src/exportToBigQuery --datasetId mydata --tableId records --projectId el-gato
+`,
+  {
+    flags: {
+      datasetId: {type: 'string'},
+      tableId: {type: 'string'},
+      projectId: {type: 'string'}
+    },
+  }
+);
+
+if (!cli.flags.datasetId) {
+  throw new Error('datasetId is required');
+}
+if (!cli.flags.tableId) {
+  throw new Error('tableId is required');
+}
+if (!cli.flags.projectId) {
+  throw new Error('projectId is required');
+}
+
+export async function main(
+  datasetId: string, 
+  tableId: string,
+  projectId: string
+): Promise<void> {
+  const repos = await getIssues();
+  const issues = new Array<Issue>();
+  repos.forEach(r => {
+    r.issues.forEach(i => {
+      i.createdAt = BigQuery.datetime(i.createdAt) as {} as string;
+      // tslint: disable-next-line no-any
+      (i as any).recordDate = BigQuery.date((new Date()).toString())
+      issues.push(i)
+    });
+  });
+  const bigquery = new BigQuery({
+    projectId: projectId
+  });
+  const result = await bigquery
+    .dataset(datasetId)
+    .table(tableId)
+    .insert(issues);
+  console.log(result);
+}
+
+main(cli.flags.datasetId, cli.flags.tableId, cli.flags.projectId).catch(err => {
+  console.error(err);
+  if (err.errors) {
+    for(const e of err.errors) {
+      console.error(e);
+    }
+  }
+  process.exit(-1);
+});

--- a/src/exportToBigQuery.ts
+++ b/src/exportToBigQuery.ts
@@ -14,8 +14,8 @@
 
 import {BigQuery} from '@google-cloud/bigquery';
 import meow = require('meow');
-import { getIssues } from './issue';
-import { Issue } from './types';
+import {getIssues} from './issue';
+import {Issue} from './types';
 
 const cli = meow(
   `
@@ -34,7 +34,7 @@ const cli = meow(
     flags: {
       datasetId: {type: 'string'},
       tableId: {type: 'string'},
-      projectId: {type: 'string'}
+      projectId: {type: 'string'},
     },
   }
 );
@@ -50,7 +50,7 @@ if (!cli.flags.projectId) {
 }
 
 export async function main(
-  datasetId: string, 
+  datasetId: string,
   tableId: string,
   projectId: string
 ): Promise<void> {
@@ -58,14 +58,16 @@ export async function main(
   const issues = new Array<Issue>();
   repos.forEach(r => {
     r.issues.forEach(i => {
-      i.createdAt = BigQuery.datetime(i.createdAt) as {} as string;
-      // tslint: disable-next-line no-any
-      (i as any).recordDate = BigQuery.date((new Date()).toISOString().slice(0,10));
+      i.createdAt = (BigQuery.datetime(i.createdAt) as {}) as string;
+      // tslint:disable-next-line no-any
+      (i as any).recordDate = BigQuery.date(
+        new Date().toISOString().slice(0, 10)
+      );
       issues.push(i);
     });
   });
   const bigquery = new BigQuery({
-    projectId: projectId
+    projectId,
   });
   const result = await bigquery
     .dataset(datasetId)
@@ -77,7 +79,7 @@ export async function main(
 main(cli.flags.datasetId, cli.flags.tableId, cli.flags.projectId).catch(err => {
   console.error(err);
   if (err.errors) {
-    for(const e of err.errors) {
+    for (const e of err.errors) {
       console.error(e);
     }
   }

--- a/src/exportToBigQuery.ts
+++ b/src/exportToBigQuery.ts
@@ -60,8 +60,8 @@ export async function main(
     r.issues.forEach(i => {
       i.createdAt = BigQuery.datetime(i.createdAt) as {} as string;
       // tslint: disable-next-line no-any
-      (i as any).recordDate = BigQuery.date((new Date()).toString())
-      issues.push(i)
+      (i as any).recordDate = BigQuery.date((new Date()).toISOString().slice(0,10));
+      issues.push(i);
     });
   });
   const bigquery = new BigQuery({

--- a/src/issue.ts
+++ b/src/issue.ts
@@ -78,7 +78,7 @@ async function getRepoIssues(repo: Repo, flags?: Flags): Promise<IssueResult> {
       isOutOfSLO: isOutOfSLO(r),
       isTriaged: isTriaged(r),
       pri: r.priorityUnknown ? undefined : getPriority(r.priority),
-      isPR: r.isPr,
+      isPR: !!r.isPr,
       number: r.issueId,
       createdAt: r.createdAt,
       title: r.title,


### PR DESCRIPTION
This sets up a nightly job, that will directly pipe raw sloth output into a BigQuery table.  This doesn't replace the other job, but gives us some ability to trend data beyond just OOSLO counts and total issue counts (specifically @leahecole was asking about trending open PRs).