### PR TITLE
fix(java): add required-checks override for googleapis/google-api-java-client-services

### DIFF
--- a/required-checks.json
+++ b/required-checks.json
@@ -43,6 +43,13 @@
           "Kokoro - Test: Linkage Monitor",
           "cla/google"
         ]
+      },
+      {
+        "repo": "googleapis/google-api-java-client-services",
+        "requiredStatusChecks": [
+          "Kokoro - Test: Java 8",
+          "cla/google"
+        ]
       }
     ]
   },


### PR DESCRIPTION
This should let us handle this repo with merge-on-green.