### PR TITLE
build: run repo settings sync nightly

### DIFF
--- a/.github/workflows/sync-repo-settings.yaml
+++ b/.github/workflows/sync-repo-settings.yaml
@@ -1,0 +1,26 @@
+name: sync-repo-settings
+on:
+  schedule:
+    - cron:  '0 1 * * *'
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+      - run: npm link
+      - run: sloth sync-repo-settings --language nodejs
+        env:
+          SLOTH_GITHUB_TOKEN: ${{ secrets.YOSHI_GITHUB_TOKEN }}
+          DRIFT_API_KEY: ${{ secrets.DRIFT_API_KEY }}
+      - run: sloth sync-repo-settings --language python
+        env:
+          SLOTH_GITHUB_TOKEN: ${{ secrets.YOSHI_GITHUB_TOKEN }}
+          DRIFT_API_KEY: ${{ secrets.DRIFT_API_KEY }}
+      - run: sloth sync-repo-settings --language java
+        env:
+          SLOTH_GITHUB_TOKEN: ${{ secrets.YOSHI_GITHUB_TOKEN }}
+          DRIFT_API_KEY: ${{ secrets.DRIFT_API_KEY }}

--- a/required-checks.json
+++ b/required-checks.json
@@ -83,6 +83,7 @@
       "test (8)",
       "test (10)",
       "test (12)",
+      "test (13)",
       "cla/google",
       "windows"
     ],
@@ -90,7 +91,8 @@
       "GoogleCloudPlatform/nodejs-docs-samples",
       "GoogleCloudPlatform/getting-started-nodejs",
       "googleapis/gapic-generator-typescript",
-      "googleapis/cloud-profiler-nodejs"
+      "googleapis/cloud-profiler-nodejs",
+      "googleapis/repo-automation-bots"
     ]
   }
 }


### PR DESCRIPTION
This takes the `sync-repo-settings` command that landed last week, and just runs it on a nightly schedule.  This way people won't have to ask me to run the script :)

Only downside I see here is needing to store the `YOSHI_AUTOMATION` token in GitHub secrets. If the better approach is to just stop and pull things into repo-automation-bots, that's ok too :)