### PR TITLE
fix: add support for Node Support

### DIFF
--- a/required-checks.json
+++ b/required-checks.json
@@ -103,12 +103,17 @@
       "windows"
     ],
     "ignoredRepos": [
-      "GoogleCloudPlatform/nodejs-docs-samples",
       "GoogleCloudPlatform/getting-started-nodejs",
       "googleapis/gapic-generator-typescript",
       "googleapis/cloud-profiler-nodejs",
       "googleapis/repo-automation-bots",
       "googleapis/google-cloud-node"
+    ],
+    "repoOverrides": [
+      {
+        "repo": "GoogleCloudPlatform/nodejs-docs-samples",
+        "useBranchProtectionRules": true
+      }
     ]
   },
   "ruby": {


### PR DESCRIPTION
Added the ability to use repo-native branch support in [this PR](https://github.com/googleapis/repo-automation-bots/pull/332)

Turning that functionality on for nodejs-docs-samples repo