### PR TITLE
fix: cloud-trace-nodejs has different requirements for tests

### DIFF
--- a/required-checks.json
+++ b/required-checks.json
@@ -118,7 +118,8 @@
       "GoogleCloudPlatform/getting-started-nodejs",
       "googleapis/cloud-profiler-nodejs",
       "googleapis/repo-automation-bots",
-      "googleapis/google-cloud-node"
+      "googleapis/google-cloud-node",
+      "googleapis/cloud-trace-nodejs"
     ],
     "repoOverrides": [
       {


### PR DESCRIPTION
cloud-trace-nodejs is still using CircleCI, I've opened a tracking issue:

https://github.com/googleapis/cloud-trace-nodejs/issues/1207