### PR TITLE
fix: remove tswast from yoshi teams

### DIFF
--- a/users.json
+++ b/users.json
@@ -83,7 +83,6 @@
         "surferjeffatgoogle",
         "tmatsuo",
         "tseaver",
-        "tswast",
         "vishald123",
         "AlisskaPie",
         "tritone",
@@ -466,8 +465,7 @@
         "sumit-ql",
         "texasmichelle",
         "tritone",
-        "tseaver",
-        "tswast"
+        "tseaver"
       ],
       "repos": [
         "googleapis/dialogflow-python-client-v2",


### PR DESCRIPTION
I'm no longer in DevRel.