### PR TITLE
chore: ignore nodejs-getting-started/nodejs-docs-samples when updating required checks

### DIFF
--- a/required-checks.json
+++ b/required-checks.json
@@ -115,6 +115,7 @@
     ],
     "ignoredRepos": [
       "GoogleCloudPlatform/getting-started-nodejs",
+      "GoogleCloudPlatform/nodejs-getting-started",
       "googleapis/cloud-profiler-nodejs",
       "googleapis/repo-automation-bots",
       "googleapis/google-cloud-node",

--- a/required-checks.json
+++ b/required-checks.json
@@ -115,6 +115,7 @@
     ],
     "ignoredRepos": [
       "GoogleCloudPlatform/getting-started-nodejs",
+      "GoogleCloudPlatform/nodejs-docs-samples",
       "GoogleCloudPlatform/nodejs-getting-started",
       "googleapis/cloud-profiler-nodejs",
       "googleapis/repo-automation-bots",


### PR DESCRIPTION
Let's not accidentally mess with required checks when we update branch protection rules.