### PR TITLE
fix: remove the google-cloud-cpp-bigquery repo

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -2,7 +2,6 @@
   "repos": [
     { "language": "cpp", "repo": "googleapis/cpp-cmakefiles", "isTeamIssue": true},
     { "language": "cpp", "repo": "googleapis/google-cloud-cpp", "isTeamIssue": true},
-    { "language": "cpp", "repo": "googleapis/google-cloud-cpp-bigquery", "isTeamIssue": true},
     { "language": "cpp", "repo": "googleapis/google-cloud-cpp-common", "isTeamIssue": true},
     { "language": "cpp", "repo": "googleapis/google-cloud-cpp-pubsub", "isTeamIssue": true},
     { "language": "cpp", "repo": "googleapis/google-cloud-cpp-spanner", "isTeamIssue": true},


### PR DESCRIPTION
This repo has been archived https://github.com/googleapis/google-cloud-cpp-bigquery. Its contents has been moved into our C++ monorepo (https://github.com/googleapis/google-cloud-cpp). And our monorepo is already being tracked in this repos.json file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/sloth/631)
<!-- Reviewable:end -->
