### PR TITLE
fix: remove the google-cloud-cpp-pubsub repo

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -3,7 +3,6 @@
     { "language": "cpp", "repo": "googleapis/cpp-cmakefiles", "isTeamIssue": true},
     { "language": "cpp", "repo": "googleapis/google-cloud-cpp", "isTeamIssue": true},
     { "language": "cpp", "repo": "googleapis/google-cloud-cpp-common", "isTeamIssue": true},
-    { "language": "cpp", "repo": "googleapis/google-cloud-cpp-pubsub", "isTeamIssue": true},
     { "language": "cpp", "repo": "googleapis/google-cloud-cpp-spanner", "isTeamIssue": true},
     { "language": "cpp", "repo": "GoogleCloudPlatform/cpp-docs-samples", "isTeamIssue": true},
 


### PR DESCRIPTION
This repo has been archived https://github.com/googleapis/google-cloud-cpp-pubsub. Its contents have been moved into our C++ monorepo (https://github.com/googleapis/google-cloud-cpp). And our monorepo is already being tracked in this repos.json file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/sloth/643)
<!-- Reviewable:end -->
