### PR TITLE
feat: Add new team cloud-trace to users.json

### DIFF
--- a/users.json
+++ b/users.json
@@ -553,6 +553,16 @@
         "googleapis/google-cloud-cpp-pubsub",
         "googleapis/google-cloud-cpp-spanner"
       ]
+    },
+    {
+      "team": "cloud-trace",
+      "users": [
+        "kintel",
+        "ziweizhao"
+      ],
+      "repos": [
+        "googleapis/cloud-trace-nodejs"
+      ]
     }
   ]
 }


### PR DESCRIPTION
feat: Cloud-trace team is taking over cloud-trace-nodejs agent.

Fixes #652 🦕
