### PR TITLE
fix: remove bcoe from teams they're not contributing to

### DIFF
--- a/users.json
+++ b/users.json
@@ -164,7 +164,6 @@
       "team": "yoshi-ruby",
       "users": [
         "TheRoyalTnetennba",
-        "bcoe",
         "blowmage",
         "crwilcox",
         "dazuma",
@@ -188,7 +187,6 @@
       "team": "yoshi-dotnet",
       "users": [
         "amanda-tarafa",
-        "bcoe",
         "chrisdunelm",
         "evildour",
         "jskeet",


### PR DESCRIPTION
I haven't been doing work on Ruby or dotnet repos, so let's not have me on the teams.