### PR TITLE
chore: attribute documentai to cloud-ai team

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -41,6 +41,7 @@
         "cloudiot",
         "datalabeling",
         "dialogflow",
+        "documentai",
         "language",
         "ml",
         "recommender",


### PR DESCRIPTION
@d-torres Is this attribution correct?