### PR TITLE
fix: update teams.json to fix ownership of "notebooks" API

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -48,6 +48,7 @@
         "documentai",
         "language",
         "ml",
+        "notebooks",
         "recommender",
         "speech",
         "texttospeech",
@@ -68,7 +69,6 @@
         "datacatalog",
         "dataflow",
         "dataproc",
-        "notebooks",
         "pubsub",
         "pubsublite"
       ]


### PR DESCRIPTION
Fixes #781 🦕
