### PR TITLE
build: nightly flake tracking; fix releasetool perms

### DIFF
--- a/.kokoro/release/publish.cfg
+++ b/.kokoro/release/publish.cfg
@@ -49,7 +49,7 @@ before_action {
 
 env_vars: {
   key: "SECRET_MANAGER_KEYS"
-  value: "npm_publish_token"
+  value: "npm_publish_token,releasetool-publish-reporter-app,releasetool-publish-reporter-googleapis-installation,releasetool-publish-reporter-pem"
 }
 
 # Download trampoline resources.

--- a/.kokoro/samples-test.sh
+++ b/.kokoro/samples-test.sh
@@ -41,7 +41,7 @@ if [ -f samples/package.json ]; then
     cd ..
     # If tests are running against master, configure Build Cop
     # to open issues on failures:
-    if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+    if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
       export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
       export MOCHA_REPORTER=xunit
       cleanup() {

--- a/.kokoro/system-test.sh
+++ b/.kokoro/system-test.sh
@@ -35,7 +35,7 @@ npm install
 
 # If tests are running against master, configure Build Cop
 # to open issues on failures:
-if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
   export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
   export MOCHA_REPORTER=xunit
   cleanup() {

--- a/.kokoro/test.sh
+++ b/.kokoro/test.sh
@@ -23,7 +23,7 @@ cd $(dirname $0)/..
 npm install
 # If tests are running against master, configure Build Cop
 # to open issues on failures:
-if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]] || [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"nightly"* ]]; then
   export MOCHA_REPORTER_OUTPUT=test_output_sponge_log.xml
   export MOCHA_REPORTER=xunit
   cleanup() {


### PR DESCRIPTION
* fixes permissions for releasetool, such that it should again report on publications.
* begin tracking flaky tests for nightly builds.