### PR TITLE
feat: add retry logic with backoff

### DIFF
--- a/src/issue.ts
+++ b/src/issue.ts
@@ -90,7 +90,6 @@ async function getRepoIssues(repo: Repo, flags?: Flags): Promise<IssueResult> {
     let tries = 0;
     while (tries < nBackoff) {
       try {
-        console.log(tries);
         res = await request<IssuesApiResponse>({url});
         break;
       } catch (e) {


### PR DESCRIPTION
Detects if an API call to DRGHS returns a non 404 error code (which
indicates the repository is not being tracked in DRGHS) and will retry
with a backoff (up to 5 times with the 5th time being a 16 second wait).