### PR TITLE
chore: update teams.json

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -18,8 +18,6 @@
       "apis": [
         "logging",
         "clouderrorreporting",
-        "monitoring",
-        "cloudtrace"
       ],
       "repos": [
         "googleapis/nodejs-logging-winston",


### PR DESCRIPTION
Remove monitoring and trace API ownership from the observability team. We don't cover that yet.

