### PR TITLE
feat: add storage and database teams

### DIFF
--- a/teams.json
+++ b/teams.json
@@ -14,6 +14,24 @@
       ]
     },
     {
+      "name": "storage",
+      "apis": [
+        "redis",
+        "storage",
+        "storagetransfer"
+      ]
+    },
+    {
+      "name": "databases",
+      "apis": [
+        "bigtable",
+        "cloudsql",
+        "datastore",
+        "firestore",
+        "ndb"
+      ]
+    },
+    {
       "name": "operations",
       "apis": [
         "logging",

--- a/teams.json
+++ b/teams.json
@@ -1,19 +1,6 @@
 {
   "teams": [
     {
-      "name": "soda",
-      "apis": [
-        "bigtable",
-        "cloudsql",
-        "datastore",
-        "firestore",
-        "ndb",
-        "redis",
-        "storage",
-        "storagetransfer"
-      ]
-    },
-    {
       "name": "storage",
       "apis": [
         "redis",


### PR DESCRIPTION
I have not removed the combined team to make sure not to break other stats.

Adding the two teams is useful as these are separate working groups within soda and at times being able to drill down into one part of SoDa is beneficial.