### PR TITLE
chore: adds bigtabletableadmin to Cloud/GCP denylist

### DIFF
--- a/src/services.json
+++ b/src/services.json
@@ -55,6 +55,7 @@
       "category": "Cloud/GCP",
       "services": [
         "baremetalsolution",
+        "bigtabletableadmin",
         "cloudlatencytest",
         "cloudvideosearch",
         "containerthreatdetection",


### PR DESCRIPTION
bigtable**table**admin is a redundant service (APIs effectively included in bigtableadmin)
