### PR TITLE
chore: update anthos-edge-usecases repo name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [10, 12, 14, 16]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/src/repos.json
+++ b/src/repos.json
@@ -66,7 +66,7 @@
 
     { "language": "yaml", "repo": "GoogleCloudPlatform/workflows-samples"},
     { "language": "yaml", "repo": "GoogleCloudPlatform/anthos-service-mesh-samples", "isTeamIssue": true},
-    { "language": "yaml", "repo": "GoogleCloudPlatform/anthos-edge-usecases", "isTeamIssue": true},
+    { "language": "yaml", "repo": "GoogleCloudPlatform/point-of-sale", "isTeamIssue": true},
 
     { "language": "terraform", "repo": "GoogleCloudPlatform/anthos-samples", "isTeamIssue": true},
     { "language": "bash", "repo": "GoogleCloudPlatform/anthos-config-management-samples", "isTeamIssue": true}

--- a/src/teams.json
+++ b/src/teams.json
@@ -87,7 +87,7 @@
         "GoogleCloudPlatform/microservices-demo",
         "GoogleCloudPlatform/kubernetes-engine-samples",
         "GoogleCloudPlatform/anthos-config-management-samples",
-        "GoogleCloudPlatform/anthos-edge-usecases",
+        "GoogleCloudPlatform/point-of-sale",
         "GoogleCloudPlatform/anthos-service-mesh-samples",
         "GoogleCloudPlatform/anthos-samples"
       ]


### PR DESCRIPTION
Fixes None
- Anthos/GKE DPE team is renaming the [anthos-edge-usecases](https://github.com/GoogleCloudPlatform/anthos-edge-usecases) repo to `point-of-sale`
- Thus we would like the sloth sheets updated so that when the change happens we can merge it