### PR TITLE
chore: adding additional api-labels for infra-databases team

### DIFF
--- a/src/teams.json
+++ b/src/teams.json
@@ -26,6 +26,9 @@
       "name": "infra-databases",
       "apis": [
         "cloudsql",
+        "cloudsql-mysql",
+        "cloudsql-postgres",
+        "cloudsql-sqlserver",
         "redis",
         "memcache"
       ],


### PR DESCRIPTION
Follow-up to cl/446833975 mapping labels to products

Added Github labels to Cloud SQL product variants in the labels-to-products mapping CL, which included adding additional labels. I _believe_ the right thing to do now is to add those additional labels to this file in order to get them to be mapped to the InfraDB team. If this is incorrect, please advise otherwise! 😄 
