### PR TITLE
meta: add additional core/automation repos

### DIFF
--- a/src/teams.json
+++ b/src/teams.json
@@ -9,7 +9,9 @@
         "googleapis/release-please",
         "googleapis/releasetool",
         "googleapis/repo-automation-bots",
-        "googleapis/synthtool"
+        "googleapis/sloth",
+        "googleapis/synthtool",
+        "google-github-actions/release-please-action"
       ]
     },
     {
@@ -243,6 +245,15 @@
       ],
       "repos": [
         "googleapis/elixir-google-api"
+      ]
+    },
+    {
+      "name": "core-nodejs",
+      "apis": [
+
+      ],
+      "repos": [
+        "google/gts"
       ]
     },
     {


### PR DESCRIPTION
Experimenting with repositories outside of googleapis/GoogleCloudPlatform.

BEGIN_COMMIT_OVERRIDE
feat: add additional core/automation repos
END_COMMIT_OVERRIDE