### PR TITLE
fix: preserve field names in the first row

### DIFF
--- a/src/exportToSheets.ts
+++ b/src/exportToSheets.ts
@@ -75,10 +75,11 @@ export async function exportToSheets() {
     version: 'v4',
     auth: await fixtures.getClient(),
   });
-  // clear the current text in the sheet
+  // clear the current text in the sheet except for the field labels
+  // on the first row.
   await sheets.spreadsheets.values.clear({
     spreadsheetId,
-    range: 'A1:Z10000',
+    range: 'A2:Z10000',
   });
 
   // insert it into the sheet

--- a/src/fetchServices.ts
+++ b/src/fetchServices.ts
@@ -167,10 +167,11 @@ export async function exportApisToSheets() {
   const values = await getResults();
   values.unshift(['Service', 'Title', 'Group', 'HasSurface', 'InScope', 'ToS']);
 
-  // clear the current text in the sheet
+  // clear the current text in the sheet except for the field labels
+  // on the first row.
   await sheets.spreadsheets.values.clear({
     spreadsheetId,
-    range: 'all_apis!A1:Z10000',
+    range: 'all_apis!A2:Z10000',
   });
 
   // insert it into the sheet

--- a/test/test.exportToSheets.ts
+++ b/test/test.exportToSheets.ts
@@ -71,7 +71,7 @@ describe('exportToSheets', () => {
     const sheetPath =
       '/v4/spreadsheets/1VV5Clqstgoeu1qVwpbKkYOxwEgjvhMhSkVCBLMqg24M';
     const scope = nock('https://sheets.googleapis.com')
-      .post(`${sheetPath}/values/A1%3AZ10000:clear`)
+      .post(`${sheetPath}/values/A2%3AZ10000:clear`)
       .reply(200)
       .post(`${sheetPath}/values:batchUpdate`)
       .reply(200);


### PR DESCRIPTION
fixes #1087

This is still ugly, but it won't break the internal datastudio, I think.
